### PR TITLE
speed improvement; infinite loop avoidance; readability

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -18,9 +18,7 @@ dependencies:
   - tqdm
   - pyproj
   - fiona
-  - netcdf4
   - shapely
-  - networkx
   - s3fs
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,7 @@ dependencies = [
   "tqdm",
   "pyproj",
   "fiona",
-  "netcdf4",
   "shapely",
-  "networkx",
   "s3fs"
 ]
 requires-python = ">= 3.10"

--- a/src/arc/Automated_Rating_Curve_Generator.py
+++ b/src/arc/Automated_Rating_Curve_Generator.py
@@ -210,7 +210,7 @@ def write_output_raster(s_output_filename: str, dm_raster_data: np.ndarray, i_nu
     o_driver = gdal.GetDriverByName(s_file_format)  # Typically will be a GeoTIFF "GTiff"
     
     # Construct the file with the appropriate data shape
-    o_output_file = o_driver.Create(s_output_filename, xsize=i_number_of_columns, ysize=i_number_of_rows, bands=1, eType=s_output_type)
+    o_output_file = o_driver.Create(s_output_filename, xsize=i_number_of_columns, ysize=i_number_of_rows, bands=1, eType=s_output_type, options=['COMPRESS=LZW', "PREDICTOR=2"])
     
     # Set the geotransform
     o_output_file.SetGeoTransform(l_dem_geotransform)


### PR DESCRIPTION
While trying to scale this up world wide, we've encountered a few issues and attempted to fix them here:

- While calculating bathymetry depth, we've encountered infinite loops. Added a check to break out if depth is greater than 25 meters
-  Finding the WSE takes the most time, whether as the objective function or otherwise. I added logic to test 10 locations between the max depth and the min depth, and this gave me a 2x speed while producing the same results
- Added the ability to save output text files as parquets, simply by using ".parquet" as the extension in the output file names
- Compression enabled by default on output rasters. This comes at almost no compute cost and massively reduces file sizes.
- A few minor memory-saving and readability edits