### PR TITLE
fixed vdt file creation using faster method

### DIFF
--- a/src/arc/Automated_Rating_Curve_Generator.py
+++ b/src/arc/Automated_Rating_Curve_Generator.py
@@ -3838,10 +3838,10 @@ def main(MIF_Name: str, args: dict, quiet: bool):
                         if b_modified_dem:
                             da_total_wse -= 100
 
-                        q_list.append(da_total_q[1:])
-                        v_list.append(da_total_v[1:])
-                        t_list.append(da_total_t[1:])
-                        wse_list.append(da_total_wse[1:])
+                        q_list.append(da_total_q[1:].copy())
+                        v_list.append(da_total_v[1:].copy())
+                        t_list.append(da_total_t[1:].copy())
+                        wse_list.append(da_total_wse[1:].copy())
 
                         if b_modified_dem:
                             da_total_wse += 100
@@ -3939,10 +3939,10 @@ def main(MIF_Name: str, args: dict, quiet: bool):
                     if b_modified_dem:
                         da_total_wse -= 100
 
-                    q_list.append(da_total_q[1:])
-                    v_list.append(da_total_v[1:])
-                    t_list.append(da_total_t[1:])
-                    wse_list.append(da_total_wse[1:])
+                    q_list.append(da_total_q[1:].copy())
+                    v_list.append(da_total_v[1:].copy())
+                    t_list.append(da_total_t[1:].copy())
+                    wse_list.append(da_total_wse[1:].copy())
 
                     if b_modified_dem:
                         da_total_wse += 100

--- a/src/arc/__init__.py
+++ b/src/arc/__init__.py
@@ -5,4 +5,4 @@ from .streamflow_processing import Create_ARC_Streamflow_Input
 from .process_geospatial_data import Process_ARC_Geospatial_Data
 
 __all__ = ['Arc', 'Run_Main_Curve_to_GEOJSON_Program_Stream_Vector', 'Create_ARC_Streamflow_Input', 'Process_ARC_Geospatial_Data']
-__version__ = '0.2.2'
+__version__ = '0.2.4'


### PR DESCRIPTION
Joseph,

You are write, my last commit would keep the last cross-sections' q-v-d-wse values, because I was appending a mutable ndarray to a list. That was my bad. I added a simple fix in this commit (copying the array into the list). In the future I'll be more vigilant in confirming the validity of any changes I send your way

Ricky